### PR TITLE
Add license metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
   { name="Mike Hoolehan", email="mike@starheightmedia.com" },
 ]
 description = "Utilities and helpers for integrating Django + Vue"
+license = { file = "LICENSE" }
 readme = "README.rst"
 requires-python = ">=3.7"
 classifiers = [


### PR DESCRIPTION
Apparently the license is now a required piece of metadata. Without this license metadata the installation of the package will fail.

Fixes #2 

